### PR TITLE
fixes utils to retrieve X, rather than X(X+1)/2, urls

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ var mkdirp = require("mkdirp");
 var path = require("path");
 var xml2js = require("xml2js");
 var parser = new xml2js.Parser({explicitArray: false});
+var bucket = "http://transifex.webmaker.org.s3.amazonaws.com/";
 
 function parse_xml_sync(buffer, callback) {
   parser.parseString(buffer, function (err, result) {
@@ -14,63 +15,63 @@ function parse_xml_sync(buffer, callback) {
   });
 }
 
-var bucket = "http://transifex.webmaker.org.s3.amazonaws.com/";
-
-module.exports.list_files = function(options, callback) {
-  var length = options.languages ? options.languages.length: 0;
-  var list = [];
-  if(options.languages) {
-    var counter = 0;
-    for (var i = 0; i < length; i++) {
-      var baseUrl = bucket + "?prefix=" + options.app + "/" + options.languages[i] + "/";
-      var url = baseUrl;
-      getAllObjects(url, [], function(err, l) {
-        counter++;
-        list = l.concat(list);
-        if(options.languages.length == counter) {
-          return callback(null, list);
+function getAllObjects(baseUrl, url, aggregate, callback) {
+  aggregate = aggregate || [];
+  var req = hyperquest.get(url);
+  req.on("error", callback);
+  req.on("response", function(res) {
+    var bodyParts = []
+    var bytes = 0;
+    res.on("data", function (c) {
+      bodyParts.push(c);
+      bytes += c.length;
+    });
+    res.on("end", function() {
+      var body = Buffer.concat(bodyParts, bytes);
+      parse_xml_sync(body, function(err, json) {
+        if(err) {
+          return callback(err);
+        }
+        if(json.ListBucketResult.Contents) {
+          var newcontent = json.ListBucketResult.Contents.map(function(content) {
+            return bucket + content.Key;
+          });
+          aggregate = aggregate.concat(newcontent);
+        }
+        if(json.ListBucketResult.IsTruncated && json.ListBucketResult.Contents) {
+          url = baseUrl + "&marker=" + json.ListBucketResult.Contents[json.ListBucketResult.Contents.length-1].Key;
+          getAllObjects(baseUrl, url, aggregate, callback);
+        }
+        // no more results to aggregate
+        else {
+          callback(null, aggregate);
         }
       });
+    });
+  });
+}
+
+module.exports.list_files = function(options, callback) {
+  var languages = options.languages;
+  if(languages) {
+    var list = [];
+    var counter = 0;
+    var last = languages.length;
+    var processResults = function(err, found) {
+      counter++;
+      list = list.concat(found);
+      if(counter === last) {
+        return callback(false, list);
+      }
     };
+    languages.forEach(function(language) {
+      var baseUrl = bucket + "?prefix=" + options.app + "/" + language + "/";
+      getAllObjects(baseUrl, baseUrl, [], processResults);
+    });
   } else {
     var baseUrl = bucket + "?prefix=" + options.app;
-    var url = baseUrl;
-    getAllObjects(url, [], function(err, l) {
-      return callback(null, l);
-    });
-  }
-
-  function getAllObjects(bucketUrl, aggregate, callback) {
-    aggregate = aggregate || [];
-    var req = hyperquest.get(url);
-    req.on("error", callback);
-    req.on("response", function(res) {
-      var bodyParts = []
-      var bytes = 0;
-      res.on("data", function (c) {
-        bodyParts.push(c);
-        bytes += c.length;
-      });
-      res.on("end", function() {
-        var body = Buffer.concat(bodyParts, bytes);
-        parse_xml_sync(body, function(err, json) {
-          if(err) {
-            return callback(err);
-          }
-          if(json.ListBucketResult.Contents) {
-            aggregate = aggregate.concat(json.ListBucketResult.Contents.map(function(content) {
-              return bucket + content.Key;
-            }));
-          }
-          if(json.ListBucketResult.IsTruncated && json.ListBucketResult.Contents) {
-            url = baseUrl + "&marker=" + json.ListBucketResult.Contents[json.ListBucketResult.Contents.length-1].Key;
-            getAllObjects(url, aggregate, callback);
-          } else {
-            // nope, no more.
-            callback(null, aggregate);
-          }
-        });
-      });
+    getAllObjects(baseUrl, baseUrl, [], function(err, found) {
+      return callback(false, found);
     });
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,14 +33,25 @@ function getAllObjects(baseUrl, url, aggregate, callback) {
           return callback(err);
         }
         if(json.ListBucketResult.Contents) {
-          var newcontent = json.ListBucketResult.Contents.map(function(content) {
+          var newcontent = json.ListBucketResult.Contents;
+          if (!newcontent.map) {
+            newcontent = [newcontent];
+          }
+          newcontent = newcontent.map(function(content) {
             return bucket + content.Key;
           });
           aggregate = aggregate.concat(newcontent);
         }
         if(json.ListBucketResult.IsTruncated && json.ListBucketResult.Contents) {
-          url = baseUrl + "&marker=" + json.ListBucketResult.Contents[json.ListBucketResult.Contents.length-1].Key;
-          getAllObjects(baseUrl, url, aggregate, callback);
+          var pos = json.ListBucketResult.Contents.length - 1;
+          if (pos > -1) {
+            var entry = json.ListBucketResult.Contents[pos];
+            url = baseUrl + "&marker=" + entry.Key;
+            getAllObjects(baseUrl, url, aggregate, callback);
+          } else {
+            // why can we get here?
+            callback(null, aggregate);
+          }
         }
         // no more results to aggregate
         else {


### PR DESCRIPTION
fixes https://github.com/mozilla/webmaker-download-locales/issues/17

https://github.com/Pomax/webmaker-download-locales/compare/fetchfix?expand=1#diff-50e3aa130a4f97a42ee2cf111c7b1d9dL29 paired with https://github.com/Pomax/webmaker-download-locales/compare/fetchfix?expand=1#diff-50e3aa130a4f97a42ee2cf111c7b1d9dL61 and https://github.com/Pomax/webmaker-download-locales/compare/fetchfix?expand=1#diff-50e3aa130a4f97a42ee2cf111c7b1d9dL67 meant download-locales was taking input languages `[a,b,c,d]` and forming the URL-fetch list `[a,a,b,a,b,c,a,b,c,d]` and so forth. With a fast enough connection, this will properly break because it leads to multiple stream write attempts the same file system location.
